### PR TITLE
Summary : Integrate SATT tool

### DIFF
--- a/satt/common/targetos/os_android.py
+++ b/satt/common/targetos/os_android.py
@@ -318,6 +318,8 @@ class AndroidOs(TargetOs):
                 index_count = 0
                 art_file_amount = len(dev_art_ls.splitlines())
                 for line in dev_art_ls.splitlines():
+		    #strip the leading and trailing spaces
+		    line = line.strip();
                     index_count += 1
                     if not line:
                         continue

--- a/satt/trace/logger/logger.py
+++ b/satt/trace/logger/logger.py
@@ -200,7 +200,7 @@ class Logger(object):
         ''' Get per cpu sideband files and combine into one sideband.bin
         '''
         self._debug_print("get_per_cpu_sideband")
-        sb_files = self._control.shell_command('ls /sys/kernel/debug/sat/cpu*_sideband').strip().split('\n')
+        sb_files = self._control.shell_command('ls /sys/kernel/debug/sat/cpu*_sideband').strip().split()
         cpu_sb_paths = []
         combined_sb = os.path.join(self.trace_path, 'sideband.bin')
         for f in sb_files:

--- a/satt/trace/logger/ram.py
+++ b/satt/trace/logger/ram.py
@@ -80,7 +80,7 @@ class RamLogger(Logger):
         self._debug_print("get_trace_data")
         # Get RTIT data of each core
         trace_streams = self._control.shell_command("ls /sys/kernel/debug/sat/*_stream")
-        trace_streams = trace_streams.strip().splitlines()
+        trace_streams = trace_streams.strip().split()
 
         off_file = open(os.path.join(self.trace_path, "cpu_offsets.txt"), "w")
         for cpu_stream in trace_streams:


### PR DESCRIPTION
Fix     : Added fix to correct the string parsing done in SATT
          without which SATT will generate wrong filenames and
          will fail to obtain the sideband data

Jira    : https://01.org/jira/browse/AIA-110

Test    : Getting proper dumps and able to visualize the data

Signed-off-by: nkumarch <naveen.kumar.chaudhary@intel.com>